### PR TITLE
Fix `neg_half`

### DIFF
--- a/src/PositionalEmbeddings.jl
+++ b/src/PositionalEmbeddings.jl
@@ -115,15 +115,15 @@ https://github.com/huggingface/transformers/issues/25199
 
 # Arguments
 - `x::AbstractArray`: Input array
-- `dim::Int=1`: Dimension along which to perform the operati    on
+- `dim::Int=1`: Dimension along which to perform the operation
 
 # Returns
 - Array with second half negated along specified dimension
 """
-function neg_half(x::AbstractArray)
-    d_2 = size(x, 1) ÷ 2
-    return vcat(-view(x, d_2+1:size(x, 1), :, :, ),
-                view(x, 1:d_2, :, :, ))
+function neg_half(x::AbstractArray, dim::Int=1)
+    d_2 = size(x, dim) ÷ 2
+    return vcat(-selectdim(x, dim, d_2+1:size(x, dim)),
+                selectdim(x, dim, 1:d_2))
 end
 
 """

--- a/src/PositionalEmbeddings.jl
+++ b/src/PositionalEmbeddings.jl
@@ -115,15 +115,15 @@ https://github.com/huggingface/transformers/issues/25199
 
 # Arguments
 - `x::AbstractArray`: Input array
-- `dim::Int=1`: Dimension along which to perform the operation
+- `dim::Integer=1`: Dimension along which to perform the operation
 
 # Returns
 - Array with second half negated along specified dimension
 """
-function neg_half(x::AbstractArray, dim::Int=1)
+function neg_half(x::AbstractArray, dim::Integer=1)
     d_2 = size(x, dim) ÷ 2
-    return vcat(-selectdim(x, dim, d_2+1:size(x, dim)),
-                selectdim(x, dim, 1:d_2))
+    return cat(-selectdim(x, dim, d_2+1:size(x, dim)),
+                selectdim(x, dim, 1:d_2), dims=dim)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,6 +139,7 @@ end
         ], (16,10,1))
 
         @test isapprox(PositionalEmbeddings.neg_half(x), expected_neg_half)
+        @test isapprox(permutedims(PositionalEmbeddings.neg_half(permutedims(x, (2,1,3)), 2), (2,1,3)), expected_neg_half)
     end
 
     @testset "Forward Pass Test" begin


### PR DESCRIPTION
This PR addresses `neg_half` not being generalized to any AbstractArray by using `selectdim` instead of view, and ensures parity with docstrings with a `dim` argument.

I previously ran into issues with multihead attention when a head dim made the array 4-dimensional.